### PR TITLE
Potential fix for code scanning alert no. 1: Regular expression injection

### DIFF
--- a/src-electron/ipc/file-explorer/ftp.js
+++ b/src-electron/ipc/file-explorer/ftp.js
@@ -1,6 +1,7 @@
 const { ipcMain, shell } = require('electron');
 const ftp = require('basic-ftp');
 const multer = require('multer');
+const _ = require('lodash');
 const upload = multer();
 const path = require('path');
 const yazl = require('yazl');
@@ -101,7 +102,10 @@ function initFtpHandler(log, ftpMap, expressApp) {
           case 'search': {
             const files = await client.list(pathParam);
             const regexFlags = req.body.caseSensitive ? '' : 'i';
-            const searchRegex = new RegExp(req.body.searchString.replace(/\*/g, '.*'), regexFlags);
+            // Escape regex metacharacters first, then replace a literal '*' with '.*' for wildcards.
+            let safeSearch = _.escapeRegExp(req.body.searchString);
+            safeSearch = safeSearch.replace(/\\\*/g, '.*'); // Replace escaped '*' (now '\\*') with '.*'
+            const searchRegex = new RegExp(safeSearch, regexFlags);
 
             const formattedFiles = files.filter(item => {
               const isHidden = item.name.startsWith('.');


### PR DESCRIPTION
Potential fix for [https://github.com/invince/YAET/security/code-scanning/1](https://github.com/invince/YAET/security/code-scanning/1)

To fix this regular expression injection vulnerability, sanitize the user input (`req.body.searchString`) before embedding it in a regex. The optimal way is to escape all regex metacharacters except for the wildcard `*`, which is intentionally translated into `.*`. The widely accepted method is to use the `_.escapeRegExp` function from the `lodash` library, which escapes all regex metacharacters. To preserve the intended wildcard functionality, first escape the user input, then replace the escaped `*` (`\\*`) with `.*`. This can be done as follows:

1. Add import for lodash (`const _ = require('lodash');`) to the top of the file if not already present.
2. In the code handling the `/api/v1/ftp/:id` route's `search` action, replace the current construction of `searchRegex` (line 104) so that the user input is first escaped and then the wildcard processed.
3. This ensures only the `*` character translates into the regex wildcard, and other special characters are safely escaped.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
